### PR TITLE
feat(payments): 결제(payments) api 4개 추가

### DIFF
--- a/libs/resource/payment/index.ts
+++ b/libs/resource/payment/index.ts
@@ -35,6 +35,60 @@ export class PaymentResource {
     const { data: payment } = await this.httpClient.get<Payment>(url);
     return payment;
   }
+
+  /**
+   * 승인된 결제를 orderId로 조회합니다.
+   * @param orderId 상점에서 주문 건을 구분하기 위해 발급한 고유 ID입니다. 영문 대소문자, 숫자, 특수문자 -, _, =로 이루어진 6자 이상 64자 이하의 문자열이어야 합니다.
+   * @returns 결제 조회 요청에 성공했다면 Payment 객체가 돌아옵니다.
+   * {@link https://docs.tosspayments.com/reference#orderid%EB%A1%9C-%EA%B2%B0%EC%A0%9C-%EC%A1%B0%ED%9A%8C}
+   */
+  private async retrieveByOrderId(orderId: string) {
+    const url = join(this.path, 'orders', orderId);
+    const { data: payment } = await this.httpClient.get<Payment>(url);
+    return payment;
+  }
+
+  get orders() {
+    return {
+      retrieve: this.retrieveByOrderId,
+    };
+  }
+
+  /**
+   * 승인된 결제를 paymentKey로 취소합니다.
+   * @param paymentKey 결제 건에 대한 고유한 키값입니다.
+   * @returns 결제 취소 요청에 성공했다면 Payment 객체의 cancels 필드에 취소 객체가 배열로 돌아옵니다.
+   * {@link https://docs.tosspayments.com/reference#%EA%B2%B0%EC%A0%9C-%EC%B7%A8%EC%86%8C}
+   */
+  async cancel(paymentKey: string, body: PaymentCancelBody) {
+    const url = join(this.path, paymentKey, 'cancel');
+    const { data: payment } = await this.httpClient.post<Payment>(url, body);
+    return payment;
+  }
+
+  /**
+   * 결제할 카드 정보와 orderId로 결제를 요청합니다.
+   * @param body Request Body Parameters
+   * @returns 카드 정보 결제 요청에 성공했다면 Payment 객체가 돌아옵니다.
+   * {@link https://docs.tosspayments.com/reference#%EC%B9%B4%EB%93%9C-%EC%A0%95%EB%B3%B4-%EA%B2%B0%EC%A0%9C}
+   */
+  async keyInPayment(body: KeyInPaymentBody) {
+    const url = join(this.path, 'key-in');
+    const { data: payment } = await this.httpClient.post<Payment>(url, body);
+    return payment;
+  }
+
+  /**
+   * 구매자가 원하는 은행의 가상계좌 발급을 요청합니다.
+   * @param body Request Body Parameters
+   * @returns 가상계좌 발급 요청에 성공했다면 virtualAccount 필드에 값이 있는 Payment 객체가 돌아옵니다.
+   * {@link https://docs.tosspayments.com/reference#%EA%B0%80%EC%83%81%EA%B3%84%EC%A2%8C-%EB%B0%9C%EA%B8%89-%EC%9A%94%EC%B2%AD}
+   */
+  async requestVirtualBank(body: VAccountReqBody) {
+    const url = 'virtual-accounts';
+    const { data: payment } = await this.httpClient.post(url, body);
+    return payment;
+  }
 }
 
 export interface VAccountReqBody {


### PR DESCRIPTION
# Tasks
- [x] : `GET /v1/payments/orders/{orderId}` 메서드 구현
- [x] : `POST /v1/payments/{paymentKey}/cancel` 메서드 구현
- [x] : `POST/v1/payments/key-in` 메서드 구현
- [x] : `POST/v1/virtual-accounts` 메서드 구현